### PR TITLE
feat: allow customizing setting tokens through the interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Authentication modules provides ability to attach authentication token automatic
 import { AuthService } from 'ngx-auth';
 
 @Injectable()
-export class AuthenticationService implements AuthService {
+export class AuthenticationService extends AuthService {
 
   constructor(private http: Http) {}
 
@@ -63,7 +63,7 @@ export class AuthenticationService implements AuthService {
 
 ```typescript
 const publicRoutes: Routes = [
-  { 
+  {
     path: '',
     component: LoginComponent,
     canActivate: [ PublicGuard ]
@@ -105,7 +105,7 @@ export class AuthenticationModule {
 
 ```
 
-where, 
+where,
 * ```PROTECTED_FALLBACK_PAGE_URI``` - main protected page to be redirected to, in case if user will reach public route, that is protected
 by ```PublicGuard``` and will be authenticated
 

--- a/src/auth.interceptor.ts
+++ b/src/auth.interceptor.ts
@@ -170,7 +170,7 @@ export class AuthInterceptor implements HttpInterceptor {
       (token: string) => {
         if (token) {
           return req.clone({
-            setHeaders: { Authorization: `Bearer ${token}` }
+            setHeaders: authService.getHeaders(token)
           });
         }
 

--- a/src/auth.service.ts
+++ b/src/auth.service.ts
@@ -69,4 +69,21 @@ export abstract class AuthService {
    */
   public abstract verifyTokenRequest(url: string): boolean;
 
+
+  /**
+   * Add token to headers, dependent on server
+   * set-up, by default adds a bearer token.
+   * Called by interceptor.
+   *
+   * To change behavior, override this method.
+   *
+   * @public
+   *
+   * @param {string} token
+   *
+   * @returns {[name: string]: string | string[]}
+   */
+  public getHeaders(token: string) : { [name: string]: string | string[] } {
+    return { Authorization: `Bearer ${token}` };
+  }
 }


### PR DESCRIPTION
Allow other ways of setting tokens. In our application, the token is sent in the form `{ 'x-auth-token': token }`, not the default bearer token.

This might catch a few users by surprise, as so far it's been in the docs to _implement_ (rather than _extend_) the AuthService. I'd recommend creating bumping a minor version, not releasing this as a patch.