### PR TITLE
fix: fixed incorrect data passed to verifyRefreshToken method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-auth",
-  "version": "5.1.0",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-auth",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Angular 7+ Authentication module",
   "repository": "https://github.com/serhiisol/ngx-auth",
   "keywords": [

--- a/src/auth.interceptor.ts
+++ b/src/auth.interceptor.ts
@@ -171,7 +171,7 @@ export class AuthInterceptor implements HttpInterceptor {
    */
   private skipRequest(req: HttpRequest<any>) {
     const skipRequest = this.exec('skipRequest', req);
-    const verifyRefreshToken = this.exec('verifyRefreshToken', req.url);
+    const verifyRefreshToken = this.exec('verifyRefreshToken', req);
 
     // deprecated, will be removed soon
     const verifyTokenRequest = this.exec('verifyTokenRequest', req.url);


### PR DESCRIPTION
## PR Checklist
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
- [ ] Feature
- [ ] Chore
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently `verifyRefreshToken` receives `url: string` instead of `request: HttpRequest<any>` argument.

## What is the new behavior?
`verifyRefreshToken` now will receive `request: HttpRequest<any>` argument.

Closes #54 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No