### PR TITLE
feat: add current request to refreshShouldHappen

### DIFF
--- a/src/auth.interceptor.ts
+++ b/src/auth.interceptor.ts
@@ -80,7 +80,7 @@ export class AuthInterceptor implements HttpInterceptor {
     const authService: AuthService =
       this.injector.get<AuthService>(AUTH_SERVICE);
     const refreshShouldHappen: boolean =
-      authService.refreshShouldHappen(res);
+      authService.refreshShouldHappen(res, req);
 
     if (refreshShouldHappen && !this.refreshInProgress) {
       this.refreshInProgress = true;

--- a/src/auth.service.ts
+++ b/src/auth.service.ts
@@ -32,7 +32,7 @@ export abstract class AuthService {
    *
    * Essentially checks status
    */
-  public abstract refreshShouldHappen(response: HttpErrorResponse, request: HttpRequest<any>): boolean;
+  public abstract refreshShouldHappen(response: HttpErrorResponse, request?: HttpRequest<any>): boolean;
 
   /**
    * Verify that outgoing request is refresh-token,

--- a/src/auth.service.ts
+++ b/src/auth.service.ts
@@ -32,7 +32,7 @@ export abstract class AuthService {
    *
    * Essentially checks status
    */
-  public abstract refreshShouldHappen(response: HttpErrorResponse): boolean;
+  public abstract refreshShouldHappen(response: HttpErrorResponse, request: HttpRequest<any>): boolean;
 
   /**
    * Verify that outgoing request is refresh-token,


### PR DESCRIPTION
## PR Type
- [x] Feature
- [ ] Chore
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently `refreshShouldHappen` ony receives the `HttpResponseError`, it would be convenient to also include the current request.

## What is the new behavior?
`refreshShouldHappen` additionally receives `HttpRequest`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No